### PR TITLE
Fixed type of Settings.options

### DIFF
--- a/relative-time.d.ts
+++ b/relative-time.d.ts
@@ -10,7 +10,7 @@ interface Settings {
     /**
      * @default { numeric: 'auto' }
      */
-    options?: Intl.DateTimeFormatOptions;
+    options?: Intl.RelativeTimeFormatOptions;
 }
 
 declare class RelativeTime {


### PR DESCRIPTION
The declared types of Settings.options reference the wrong internal types, causing us to have to code workarounds in our code. This fixes that.